### PR TITLE
Bump org.springframework.boot til 3.4.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id("org.springframework.boot") version "3.3.5"
+    id("org.springframework.boot") version "3.4.0"
     id("io.spring.dependency-management") version "1.1.6"
     id("org.jlleitschuh.gradle.ktlint") version "12.1.1"
     kotlin("jvm") version "2.0.21"

--- a/src/test/kotlin/no/nav/syfo/FellesTestOppsett.kt
+++ b/src/test/kotlin/no/nav/syfo/FellesTestOppsett.kt
@@ -16,8 +16,8 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.testcontainers.containers.KafkaContainer
 import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.kafka.KafkaContainer
 import org.testcontainers.utility.DockerImageName
 
 private class PostgreSQLContainer14 : PostgreSQLContainer<PostgreSQLContainer14>("postgres:14-alpine")
@@ -32,7 +32,7 @@ abstract class FellesTestOppsett {
         var pdfMockWebserver: MockWebServer
 
         init {
-            KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.1")).also {
+            KafkaContainer(DockerImageName.parse("apache/kafka-native")).also {
                 it.start()
                 System.setProperty("spring.kafka.bootstrap-servers", it.bootstrapServers)
                 System.setProperty("KAFKA_BROKERS", it.bootstrapServers)


### PR DESCRIPTION
Bruk apache/kafka-native i stedet for confluentinc/cp-kafka for mindre image og
raskere oppstart.
