### PR TITLE
Fixes vulnerabilities CVE-2018-1000613 and GHSA-4446-656p-f54g

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,6 +77,11 @@ dependencies {
     implementation("org.apache.cxf:cxf-spring-boot-starter-jaxws:$cxfVersion")
     implementation("org.apache.cxf:cxf-rt-features-logging:$cxfVersion")
     implementation("org.apache.cxf:cxf-rt-ws-security:$cxfVersion")
+    constraints {
+        implementation("org.bouncycastle:bcprov-jdk15on:1.70") {
+            because("Fixes CVE-2018-1000613 and GHSA-4446-656p-f54g")
+        }
+    }
     implementation("org.apache.cxf:cxf-rt-ws-policy:$cxfVersion")
 
     implementation("no.nav.tjenestespesifikasjoner:behandle-altinnmelding-v1-tjenestespesifikasjon:$tjenestespesifikasjonerVersion")


### PR DESCRIPTION
Legger inn et kort i Trello som minner oss på å sjekke om dette er fikset om én måned.
Kodesnutten kan fjernes dersom  cxfVersion er 4.1.1 eller over.