### PR TITLE
Fjern harRedusertVenteperiode fra testfixture

### DIFF
--- a/src/test/resources/gradertreisetilskuddarbeidstakersoknad.json
+++ b/src/test/resources/gradertreisetilskuddarbeidstakersoknad.json
@@ -868,7 +868,6 @@
   "ettersending": false,
   "mottaker": "ARBEIDSGIVER_OG_NAV",
   "egenmeldtSykmelding": false,
-  "harRedusertVenteperiode": null,
   "behandlingsdager": null,
   "permitteringer": [
     {


### PR DESCRIPTION
Fjerner `harRedusertVenteperiode: null` fra JSON testfixture. Feltet er COVID-era dead code.

NB: `SykmeldingGenerator.kt` bruker `harRedusertArbeidsgiverperiode` fra `syfosm-common-models`-biblioteket — dette kan ikke fjernes før biblioteket oppdateres av teamsykmelding.

Relatert:
- navikt/flex-sykmeldinger-backend#584
- navikt/sykepengesoknad-backend#1497